### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: "node_js"
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,5 @@ cache:
     - "node_modules"
 before_install:
   - "npm -g install npm@latest"
-  - "curl -Lo travis_after_all.py https://raw.githubusercontent.com/dmakhno/travis_after_all/master/travis_after_all.py"
-after_success:  # travis_after_all.py is needed due to travis-ci/travis-ci#1548 & travis-ci/travis-ci#929
-  - "python travis_after_all.py"
-  - "export $(cat .to_export_back)"
+after_success:
   - "npm run semantic-release || true"

--- a/package.json
+++ b/package.json
@@ -17,21 +17,21 @@
     "url": "https://github.com/apiaryio/gavel2html.git"
   },
   "dependencies": {
-    "clone": "^1.0.2",
+    "clone": "^2.1.1",
     "googlediff": "^0.1.0",
     "is-type": "~0.0.1",
-    "json-pointer": "^0.5.0",
+    "json-pointer": "^0.6.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "coffee-script": "^1.8.0",
-    "coffeeify": "^2.0.1",
-    "coffeelint": "^1.15.7",
-    "cz-conventional-changelog": "^1.1.6",
-    "mocha": "^3.0.2",
-    "mochify": "^2.18.0",
-    "semantic-release": "^4.3.5"
+    "coffee-script": "^1.12.5",
+    "coffeeify": "^2.1.0",
+    "coffeelint": "^1.16.0",
+    "cz-conventional-changelog": "^2.0.0",
+    "mocha": "^3.3.0",
+    "mochify": "^3.1.1",
+    "semantic-release": "^6.3.2"
   },
   "keywords": [
     "html",


### PR DESCRIPTION
The `travis_after_all.py` is not necessary anymore (already included in newer versions of semantic-release)