### PR TITLE
Put html-sanitizer.js back to the distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Render Gavel.js output to HTML diff",
   "main": "lib/index.js",
   "scripts": {
-    "build": "coffee -b -c -o lib/ src/",
+    "build": "npm run build:coffee-script && npm run build:html-sanitizer",
+    "build:coffee-script": "coffee -b -c -o lib/ src/",
+    "build:html-sanitizer": "node -e \"var fs = require('fs'); fs.createReadStream('src/html-sanitizer.js').pipe(fs.createWriteStream('lib/html-sanitizer.js'));\"",
     "lint": "coffeelint src",
     "test": "npm run test:server && npm run test:browser",
     "test:server": "mocha \"test/**/*.coffee\"",

--- a/src/converter.coffee
+++ b/src/converter.coffee
@@ -1,5 +1,5 @@
 binaryDetect = require './binary-detect'
-sanitizer = require './html-sanitizer.js'
+sanitizer = require './html-sanitizer'
 traverse = require 'traverse'
 jsonPointer = require 'json-pointer'
 


### PR DESCRIPTION
This fixes a mistake done in

https://github.com/apiaryio/gavel2html/commit/2aa09cbc3b9fadb146e64f9dbb81ec303f15f933#diff-596d2114d55ed0d2d1f87659c57d700eL5

In current distribution of gavel2html the html-sanitizer.js file is missing.