### PR TITLE
Add missing Gavel.js link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,5 @@ Returns an HTML string representing the markup of the validation results data di
   identString?: string = '  '
 }
 ```
+
+[Gavel.js]: https://github.com/apiaryio/gavel.js


### PR DESCRIPTION
- #26 has removed the Gavel.ks link alias from the README. This pull request reverts that. 