### PR TITLE
Fixes dollar sign handling in a body

### DIFF
--- a/src/converter.coffee
+++ b/src/converter.coffee
@@ -45,7 +45,10 @@ class Converter
     html = @getHtmlPrivate()
 
     if @wrapWith
-      html = @wrapWith.replace '##data', html
+      # Provide a function as the string replace argument
+      # to ignore string replacement sequences ($&, $1, etc.)
+      # that might have formed by the actual data.
+      html = @wrapWith.replace '##data', () -> html
 
     return html
 

--- a/src/gavel2html.coffee
+++ b/src/gavel2html.coffee
@@ -74,7 +74,10 @@ class Gavel2Html
       html += @dataReal
 
       if wrapWith
-        html = wrapWith.replace '##data', html
+        # Provide a function as the string replace argument
+        # to ignore string replacement sequences ($&, $1, etc.)
+        # that might have formed by the actual data.
+        html = wrapWith.replace '##data', () -> html
 
       return html
 

--- a/src/json-result-converter.coffee
+++ b/src/json-result-converter.coffee
@@ -150,7 +150,14 @@ class JsonResultConverter extends Converter
           writeStart(out[compiledPath])
         s += '&quot;' # sanitizeData('"')
         s += preStringValue if preStringValue
-        s += sanitizeData(node.toString().replace(/"/g, '\"'))
+        s += sanitizeData(
+          node
+            .toString()
+            .replace(/"/g, '\"')
+            # Replace the "$" character in the value to prevent it
+            # from forming a string replacement sequence ($&, $1, etc.).
+            .replace('$', '$$$')
+          )
         s += postStringValue if postStringValue
         s += '&quot;' # sanitizeData('"')
         if @isRoot

--- a/src/json-result-converter.coffee
+++ b/src/json-result-converter.coffee
@@ -156,7 +156,7 @@ class JsonResultConverter extends Converter
             .replace(/"/g, '\"')
             # Replace the "$" character in the value to prevent it
             # from forming a string replacement sequence ($&, $1, etc.).
-            .replace('$', '$$$')
+            .replace('$', '$$')
           )
         s += postStringValue if postStringValue
         s += '&quot;' # sanitizeData('"')

--- a/test/regression/dollar-sign-body-test.coffee
+++ b/test/regression/dollar-sign-body-test.coffee
@@ -23,4 +23,4 @@ describe 'Dollar sign in the body', ->
   html = diff.getHtml()
 
   it 'escapes the dollar sign in the diff', ->
-    assert.equal(html, '<li>{</li>\n<li>  &quot;symbol&quot;: &quot;$$&quot;</li>\n<li>}</li>')
+    assert.equal(html, '<li>{</li>\n<li>  &quot;symbol&quot;: &quot;$&quot;</li>\n<li>}</li>')

--- a/test/regression/dollar-sign-body-test.coffee
+++ b/test/regression/dollar-sign-body-test.coffee
@@ -1,0 +1,26 @@
+{assert} = require 'chai'
+Gavel2Html = require('../../src/index')
+
+describe 'Dollar sign in the body', ->
+  gavelResult = {
+    fields: {
+      body: {
+        kind: 'json',
+        values: {
+          actual: JSON.stringify({ symbol: '$' }),
+          expected: JSON.stringify({ symbol: 'a' }),
+        },
+        errors: []
+      }
+    }
+  }
+
+  payload = {
+    fieldName: 'body',
+    fieldResult: gavelResult.fields.body,
+  }
+  diff = new Gavel2Html payload
+  html = diff.getHtml()
+
+  it 'escapes the dollar sign in the diff', ->
+    assert.equal(html, '<li>{</li>\n<li>  &quot;symbol&quot;: &quot;$$&quot;</li>\n<li>}</li>')

--- a/test/regression/string-replacement-sequence-test.coffee
+++ b/test/regression/string-replacement-sequence-test.coffee
@@ -22,5 +22,5 @@ describe 'Dollar sign in the body', ->
   diff = new Gavel2Html payload
   html = diff.getHtml()
 
-  it 'escapes the dollar sign in the diff', ->
+  it 'escapes the string replacement sequence in the diff', ->
     assert.equal(html, '<li>{</li>\n<li>  &quot;symbol&quot;: &quot;$&quot;</li>\n<li>}</li>')


### PR DESCRIPTION
If the expected/actual values contain a dollar sign `$` it gets treated as a string replacement sequence when the diff is wrapped in a `wrapWith` template string:

https://github.com/apiaryio/gavel2html/blob/8788847be0ba2aed566a13563a91c1598ce30809/src/converter.coffee#L47-L48

This can be remediated in two steps:

1. Escape the `$` string character to prevent it from being treated as a string replace sequence.
1. Provide a function to the `@wrapWith.replace` call, so it ignores string replace sequences.